### PR TITLE
Add threading.Lock() to 'support' concurrent requests

### DIFF
--- a/.github/workflows/build-and-push-to-ghcr.yml
+++ b/.github/workflows/build-and-push-to-ghcr.yml
@@ -8,6 +8,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       -
+        name: Set owner name to lower case
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
+      -
         name: Checkout
         uses: actions/checkout@v3
 
@@ -21,7 +27,7 @@ jobs:
           docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io
 
       - name: 'Remove cache'
-        run: | 
+        run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo rm -rf "/usr/local/share/boost"
@@ -34,8 +40,8 @@ jobs:
           context: "{{defaultContext}}:server"
           file: Dockerfile
           push: false # Do not push image for PR
-          cache-from: type=registry,ref=ghcr.io/coqui-ai/xtts-streaming-server:cache-latest; type=registry,ref=ghcr.io/coqui-ai/xtts-streaming-server:cache-pr-${{ github.event.number }}
-          cache-to: type=registry,ref=ghcr.io/coqui-ai/xtts-streaming-server:cache-pr-${{ github.event.number }}
+          cache-from: type=registry,ref=ghcr.io/${{ env.OWNER_LC }}/xtts-streaming-server:cache-latest; type=registry,ref=ghcr.io/${{ env.OWNER_LC }}/xtts-streaming-server:cache-pr-${{ github.event.number }}
+          cache-to: type=registry,ref=ghcr.io/${{ env.OWNER_LC }}/xtts-streaming-server:cache-pr-${{ github.event.number }}
 
       - name: Build and Push image Cuda 11.8
         if: github.ref == 'refs/heads/main'
@@ -44,14 +50,20 @@ jobs:
           context: "{{defaultContext}}:server"
           file: Dockerfile
           push: true # Push if merged
-          cache-from: type=registry,ref=ghcr.io/coqui-ai/xtts-streaming-server:cache-latest
-          cache-to: type=registry,ref=ghcr.io/coqui-ai/xtts-streaming-server:cache-latest
-          tags: ghcr.io/coqui-ai/xtts-streaming-server:latest, ghcr.io/coqui-ai/xtts-streaming-server:main-${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/${{ env.OWNER_LC }}/xtts-streaming-server:cache-latest
+          cache-to: type=registry,ref=ghcr.io/${{ env.OWNER_LC }}/xtts-streaming-server:cache-latest
+          tags: ghcr.io/${{ env.OWNER_LC }}/xtts-streaming-server:latest, ghcr.io/${{ env.OWNER_LC }}/xtts-streaming-server:main-${{ github.sha }}
           #build-args:
 
   build-and-push-to-ghcr-cuda121:
     runs-on: ubuntu-22.04
     steps:
+      -
+        name: Set owner name to lower case
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
       -
         name: Checkout
         uses: actions/checkout@v3
@@ -66,7 +78,7 @@ jobs:
           docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io
 
       - name: 'Remove cache'
-        run: | 
+        run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo rm -rf "/usr/local/share/boost"
@@ -79,8 +91,8 @@ jobs:
           context: "{{defaultContext}}:server"
           file: Dockerfile.cuda121
           push: false # Do not push image for PR
-          cache-from: type=registry,ref=ghcr.io/coqui-ai/xtts-streaming-server:cache-latest-cuda121; type=registry,ref=ghcr.io/coqui-ai/xtts-streaming-server:cache-pr-cuda121-${{ github.event.number }}
-          cache-to: type=registry,ref=ghcr.io/coqui-ai/xtts-streaming-server:cache-pr-cuda121-${{ github.event.number }}
+          cache-from: type=registry,ref=ghcr.io/${{ env.OWNER_LC }}/xtts-streaming-server:cache-latest-cuda121; type=registry,ref=ghcr.io/${{ env.OWNER_LC }}/xtts-streaming-server:cache-pr-cuda121-${{ github.event.number }}
+          cache-to: type=registry,ref=ghcr.io/${{ env.OWNER_LC }}/xtts-streaming-server:cache-pr-cuda121-${{ github.event.number }}
 
       - name: Build and Push image cuda 12.1
         if: github.ref == 'refs/heads/main'
@@ -89,13 +101,19 @@ jobs:
           context: "{{defaultContext}}:server"
           file: Dockerfile.cuda121
           push: true # Push if merged
-          cache-from: type=registry,ref=ghcr.io/coqui-ai/xtts-streaming-server:cache-latest-cuda121
-          cache-to: type=registry,ref=ghcr.io/coqui-ai/xtts-streaming-server:cache-latest-cuda121
-          tags: ghcr.io/coqui-ai/xtts-streaming-server:latest-cuda121, ghcr.io/coqui-ai/xtts-streaming-server:main-cuda121-${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/${{ env.OWNER_LC }}/xtts-streaming-server:cache-latest-cuda121
+          cache-to: type=registry,ref=ghcr.io/${{ env.OWNER_LC }}/xtts-streaming-server:cache-latest-cuda121
+          tags: ghcr.io/${{ env.OWNER_LC }}/xtts-streaming-server:latest-cuda121, ghcr.io/${{ env.OWNER_LC }}/xtts-streaming-server:main-cuda121-${{ github.sha }}
           #build-args:
   build-and-push-to-ghcr-cpu:
     runs-on: ubuntu-22.04
     steps:
+      -
+        name: Set owner name to lower case
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
       -
         name: Checkout
         uses: actions/checkout@v3
@@ -110,7 +128,7 @@ jobs:
           docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io
 
       - name: 'Remove cache'
-        run: | 
+        run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo rm -rf "/usr/local/share/boost"
@@ -123,8 +141,8 @@ jobs:
           context: "{{defaultContext}}:server"
           file: Dockerfile.cpu
           push: false # Do not push image for PR
-          cache-from: type=registry,ref=ghcr.io/coqui-ai/xtts-streaming-server:cache-latest-cpu; type=registry,ref=ghcr.io/coqui-ai/xtts-streaming-server:cache-pr-cuda121-${{ github.event.number }}
-          cache-to: type=registry,ref=ghcr.io/coqui-ai/xtts-streaming-server:cache-pr-cpu-${{ github.event.number }}
+          cache-from: type=registry,ref=ghcr.io/${{ env.OWNER_LC }}/xtts-streaming-server:cache-latest-cpu; type=registry,ref=ghcr.io/${{ env.OWNER_LC }}/xtts-streaming-server:cache-pr-cuda121-${{ github.event.number }}
+          cache-to: type=registry,ref=ghcr.io/${{ env.OWNER_LC }}/xtts-streaming-server:cache-pr-cpu-${{ github.event.number }}
 
       - name: Build and Push image CPU
         if: github.ref == 'refs/heads/main'
@@ -133,7 +151,7 @@ jobs:
           context: "{{defaultContext}}:server"
           file: Dockerfile.cpu
           push: true # Push if merged
-          cache-from: type=registry,ref=ghcr.io/coqui-ai/xtts-streaming-server:cache-latest-cpu
-          cache-to: type=registry,ref=ghcr.io/coqui-ai/xtts-streaming-server:cache-latest-cpu
-          tags: ghcr.io/coqui-ai/xtts-streaming-server:latest-cpu, ghcr.io/coqui-ai/xtts-streaming-server:main-cpu-${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/${{ env.OWNER_LC }}/xtts-streaming-server:cache-latest-cpu
+          cache-to: type=registry,ref=ghcr.io/${{ env.OWNER_LC }}/xtts-streaming-server:cache-latest-cpu
+          tags: ghcr.io/${{ env.OWNER_LC }}/xtts-streaming-server:latest-cpu, ghcr.io/${{ env.OWNER_LC }}/xtts-streaming-server:main-cpu-${{ github.sha }}
           #build-args:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # XTTS streaming server
-
+*Warning: XTTS-streaming-server doesn't support concurrent streaming requests, it's a demo server, not meant for production.*
 
 https://github.com/coqui-ai/xtts-streaming-server/assets/17219561/7220442a-e88a-4288-8a73-608c4b39d06c
 

--- a/README.md
+++ b/README.md
@@ -81,3 +81,6 @@ $ cd xtts-streaming-server/test
 $ python -m pip install -r requirements.txt
 $ python test_streaming.py
 ```
+
+### Forked Repos
+If forked, GitHub action will  automatically build and push a Docker image to your container registry - so it will be ghcr.io/yourusername/xtts-streaming-server.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # XTTS streaming server
-*Warning: XTTS-streaming-server doesn't support concurrent streaming requests, it's a demo server, not meant for production.*
+*Warning: XTTS-streaming-server is a demo server, not meant for production.*
 
 https://github.com/coqui-ai/xtts-streaming-server/assets/17219561/7220442a-e88a-4288-8a73-608c4b39d06c
 


### PR DESCRIPTION
I wanted to be able to consume my own instances without worrying about having to queue/proxy calls via another web server.

Added in threading to get the lock object - api endpoints then are wrapped with a `with lock:` in order to ensure only 1 request is actually using the gpu at a time.